### PR TITLE
Add comprehensive documentation for Knowbase

### DIFF
--- a/documentation/AI_GUIDE.md
+++ b/documentation/AI_GUIDE.md
@@ -1,0 +1,67 @@
+# Guide pour les IA génératives
+
+Ce guide synthétise les conventions et garde-fous à respecter lorsqu’une IA modifie ou étend Knowbase.
+
+## Principes généraux
+
+1. **S’appuyer sur la documentation** :
+   - `OVERVIEW.md` pour comprendre l’architecture avant de coder.
+   - `BACKEND_APIS.md` pour identifier les endpoints existants et les services associés.
+   - `MODULES.md` et `registry.json` pour localiser rapidement les fonctions et connaître leurs signatures/dépendances.
+2. **Respect de la modularité** : chaque fonctionnalité doit passer par une couche service (dans `src/knowbase/api/services`) avant d’être exposée par un router.
+3. **Éviter la duplication** : mutualiser les appels clients via `knowbase.common.clients.shared_clients` et réutiliser `LLMRouter`/`TokenTracker`.
+4. **Observer les conventions de logging** : utiliser `knowbase.common.logging.setup_logging` ou `logging.getLogger(__name__)` selon le module.
+5. **Protéger l’isolement multi-tenant** : toujours lire/écrire le `group_id` via `UserContextMiddleware` ou `GraphitiTenantManager` lorsque vous touchez au Knowledge Graph, aux facts ou aux utilisateurs.
+
+## Nommage & structure
+
+- **Endpoints** : nouveaux routers à créer dans `src/knowbase/api/routers`, avec préfixe explicite (`/api/...`). Nommer les fonctions en snake_case et retourner des modèles Pydantic lorsque c’est pertinent.
+- **Services** : placer la logique métier dans `src/knowbase/api/services`. Préfixer les fonctions par le verbe (`create_`, `get_`, `update_`, `delete_`, `handle_`) pour refléter l’intention.
+- **Pipelines** : centraliser dans `src/knowbase/ingestion/pipelines` et exposer des fonctions `process_*` ou `main`. Utiliser des callbacks de progression si le traitement dure.
+- **Clients externes** : ajouter les initialisations dans `src/knowbase/common/clients` pour profiter du cache partagé.
+
+## Variables d’environnement clés
+
+| Variable | Usage | Fichier de référence |
+| --- | --- | --- |
+| `KNOWBASE_DATA_DIR` | Racine du dossier `data/` (docs, logs, modèles) | `config/settings.py` |
+| `QDRANT_URL`, `QDRANT_API_KEY` | Connexion Qdrant | `common/clients/qdrant_client.py` |
+| `OPENAI_API_KEY`, `ANTHROPIC_API_KEY` | Accès LLM | `common/clients/openai_client.py`, `common/clients/anthropic_client.py` |
+| `GRAPHITI_URL`, `GRAPHITI_AUTH_TOKEN` | Connexion Graphiti store | `common/graphiti/config.py` |
+| `REDIS_URL`, `INGESTION_QUEUE` | Workers RQ | `ingestion/queue/connection.py` |
+| `PUBLIC_URL` | Génération de liens statiques | `services/search.py`, `services/status.py` |
+
+## Entry points & démarrage
+
+- **API FastAPI** : `app/main.py` instancie `create_app()`.
+- **Workers ingestion** : `python -m knowbase.ingestion.queue` ou `ingestion/queue/worker.py:main()`.
+- **UI Streamlit** : `ui/app.py` ou `src/knowbase/ui/streamlit_app.py`.
+- **Scripts CLI** : `scripts/` contient des utilitaires (purge Qdrant, export Graphiti, validation). Toujours vérifier les options avant exécution.
+
+## Ajouter un nouvel endpoint
+
+1. Définir/étendre les schémas Pydantic dans `src/knowbase/api/schemas`.
+2. Implémenter la logique métier dans un service (`src/knowbase/api/services`).
+3. Créer la route dans `src/knowbase/api/routers/…` en important le service.
+4. Mettre à jour `BACKEND_APIS.md`, `MODULES.md` et `registry.json` (section correspondante) pour garder la documentation synchronisée.
+5. Ajouter des tests ciblés dans `tests/` (ou `app/tests/` pour la version conteneurisée).
+
+## Gestion des dépendances & clients
+
+- Utiliser `get_settings()` pour accéder aux chemins et secrets. Ne pas lire directement `os.environ` dans les modules applicatifs (sauf dans les settings).
+- Pour Qdrant, embeddings et LLM : appeler les helpers (`get_qdrant_client()`, `get_sentence_transformer()`, `LLMRouter`) afin de bénéficier du cache et du warm-up.
+- Les jobs RQ doivent toujours appeler `mark_job_as_processing()` au début et `update_job_progress()` régulièrement pour alimenter l’historique Redis.
+
+## Sécurité & gouvernance des données
+
+- Les fonctions Knowledge Graph et Facts doivent systématiquement appeler `UserKnowledgeGraphService.set_group` ou `FactsGovernanceService.set_group` via le contexte utilisateur.
+- Lors de la suppression d’un import (`delete_import_completely`), veiller à nettoyer Qdrant, Redis et le filesystem pour éviter les orphelins.
+- Les métadonnées utilisateur/tenant sont persistées dans des fichiers JSON ; utiliser les services dédiés pour garantir l’intégrité et éviter les conflits de verrouillage.
+
+## Tests & validation
+
+- Lancer `pytest` depuis la racine pour couvrir `src/knowbase`.
+- Des tests d’intégration Graphiti/Qdrant sont fournis (`tests/integration/...`). Vérifiez que les environnements externes (Neo4j, Graphiti API, Qdrant) sont disponibles avant d’exécuter ces tests.
+- Le script `test_phase2_validation.py` récapitule les checks phares de la phase 2 ; utilisez-le après de grosses refontes ingestion/KG.
+
+En suivant ces conventions, une IA peut contribuer en toute sécurité sans casser les workflows critiques (ingestion, recherche, gouvernance, KG). Toute extension doit maintenir la cohérence de cette documentation.

--- a/documentation/BACKEND_APIS.md
+++ b/documentation/BACKEND_APIS.md
@@ -1,0 +1,165 @@
+# Catalogue des APIs FastAPI
+
+Ce document référence l’ensemble des endpoints exposés par `create_app()` (`src/knowbase/api/main.py`). Chaque section correspond à un router et détaille : méthode, chemin final (avec préfixe), schémas de requête/réponse, services internes appelés, dépendances externes (Qdrant, Redis, LLM, Graphiti…). Les schémas mentionnés sont ceux définis dans `src/knowbase/api/schemas`.
+
+> ℹ️ Tous les endpoints héritent du middleware `UserContextMiddleware` qui extrait les en-têtes (`X-User-ID`, `X-Group-ID`, etc.) pour contextualiser les appels multi-tenant.
+
+## Recherche (`src/knowbase/api/routers/search.py`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `POST /search` | `SearchRequest` (question, option solution) | objet `{"status", "results", "synthesis"}` | `search_documents()` | Qdrant (`get_qdrant_client`), SentenceTransformer (`get_sentence_transformer`), reranker + LLM (`synthesize_response`) |
+| `GET /solutions` | Query vide | `List[str]` | `get_available_solutions()` | Qdrant scroll collection principale |
+
+## Ingestion (`src/knowbase/api/routers/ingest.py`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `POST /dispatch` | Form-data (`action_type`, `document_type`, `question`, `file`, `meta`) | Status JSON (search, ingest, fill) | `handle_dispatch()` | Qdrant, SentenceTransformer, OpenAI (canonicalisation), Redis Queue (`enqueue_*`), Redis import history |
+| `POST /documents/upload-excel-qa` | `UploadFile` Excel + option meta | Status JSON | `handle_excel_qa_upload()` | Redis import history, Redis Queue (Excel ingestion) |
+| `POST /documents/fill-excel-rfp` | `UploadFile` Excel + option meta | Status JSON | `handle_excel_rfp_fill()` | Redis import history, Redis Queue (smart fill), OpenAI canonicalisation |
+| `POST /documents/analyze-excel` | `UploadFile` Excel | Analyse des onglets (liste colonnes, échantillons) | `analyze_excel_file()` | pandas, openpyxl |
+
+## Statut ingestion (`src/knowbase/api/routers/status.py`, préfixe `/api`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/status/{uid}` | UID job | `{"action", "status", ...}` | `job_status()` | Redis Queue (`fetch_job`), Redis import history |
+
+## Historique d’import (`src/knowbase/api/routers/imports.py`, préfixe `/api`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/imports/history` | `limit` (int) | Liste des enregistrements | `RedisImportHistoryService.get_history()` | Redis DB1 |
+| `GET /api/imports/active` | — | Liste imports actifs | `RedisImportHistoryService.get_active_imports()` | Redis DB1 + Queue RQ |
+| `POST /api/imports/sync` | — | `{message, synced_count}` | `RedisImportHistoryService.sync_orphaned_jobs()` | Redis DB1 + Queue RQ |
+| `POST /api/imports/cleanup` | `days` | `{message, deleted_count}` | `RedisImportHistoryService.cleanup_old_records()` | Redis DB1 |
+| `DELETE /api/imports/{uid}/delete` | UID | `{message, deleted_items}` | `import_deletion.delete_import_completely()` | Redis DB1, Qdrant, stockage disque |
+
+## Solutions SAP (`src/knowbase/api/routers/sap_solutions.py`, préfixe `/api/sap-solutions`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/sap-solutions/` | — | `SolutionsListResponse` | `SAPSolutionsManager.get_solutions_list()` | Lecture YAML `config/sap_solutions.yaml` |
+| `POST /api/sap-solutions/resolve` | `SolutionResolveRequest` | `SolutionResolveResponse` | `SAPSolutionsManager.resolve_solution()` | LLMRouter (OpenAI/Anthropic), YAML |
+| `GET /api/sap-solutions/search/{query}` | Path `query` | `SolutionsListResponse` | `SAPSolutionsManager.get_solutions_list()` (filtrage) | YAML |
+| `GET /api/sap-solutions/with-chunks` | `extend_search` bool | `SolutionsListResponse` | `get_sap_solutions_manager().get_solutions_list()` + Qdrant scroll | Qdrant (collections principale & `rfp_qa`) |
+
+## Téléchargements (`src/knowbase/api/routers/downloads.py`, préfixe `/api/downloads`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/downloads/filled-rfp/{uid}` | UID | `FileResponse` Excel | `RedisImportHistoryService.get_import_by_uid()` | Système de fichiers (`presentations_dir`), historique Redis |
+| `GET /api/downloads/import-files/{uid}` | UID | `FileResponse` | `RedisImportHistoryService.get_import_by_uid()` | Système de fichiers (`docs_done`, `docs_in`) |
+
+## Analyse des tokens (`src/knowbase/api/routers/token_analysis.py`, préfixe `/api/tokens`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/tokens/stats` | — | `{stats_by_model, total_cost, total_usage_count}` | `get_token_tracker().get_stats_by_model()` | Historique en mémoire |
+| `GET /api/tokens/estimate-deck` | `num_slides`, `model`, `avg_input_tokens`, `avg_output_tokens` | `DeckCostEstimate` | `TokenTracker.estimate_deck_cost()` | Barème de coûts intégré |
+| `GET /api/tokens/compare-providers` | `input_tokens`, `output_tokens`, `base_model` | Comparaison coûts | `TokenTracker.compare_providers()` | Tarifs intégrés |
+| `GET /api/tokens/cost-by-task` | — | Stats par type de tâche | Agrégation `TokenTracker` | — |
+| `GET /api/tokens/pricing` | — | Détail tarifs | `TokenTracker.MODEL_PRICING` | — |
+| `POST /api/tokens/reset` | — | `{message}` | `TokenTracker.usage_history.clear()` | — |
+| `GET /api/tokens/sagemaker-savings` | `num_slides`, `current_model`, `avg_input_tokens`, `avg_output_tokens` | Analyse d’économies | `TokenTracker.estimate_deck_cost()` | Tarifs intégrés |
+
+## Tenants (`src/knowbase/api/routers/tenants.py`, préfixe `/api/tenants`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `POST /api/tenants/` | `TenantCreateRequest` | `Tenant` | `TenantService.create_tenant()` | Fichiers JSON sous `/data/tenants` |
+| `GET /api/tenants/` | `page`, `page_size`, filtres | `TenantListResponse` | `TenantService.list_tenants()` | Fichiers JSON |
+| `GET /api/tenants/{tenant_id}` | Path | `Tenant` | `TenantService.get_tenant()` | Fichiers JSON |
+| `PUT /api/tenants/{tenant_id}` | `TenantUpdate` | `Tenant` | `TenantService.update_tenant()` | Fichiers JSON |
+| `DELETE /api/tenants/{tenant_id}` | Path | 204 | `TenantService.delete_tenant()` | Fichiers JSON |
+| `POST /api/tenants/{tenant_id}/users` | `AddUserToTenantRequest` | `UserTenantMembership` | `TenantService.add_user_to_tenant()` | Fichiers JSON |
+| `GET /api/tenants/{tenant_id}/users` | Path | Liste memberships | `TenantService.get_tenant_users()` | Fichiers JSON |
+| `GET /api/tenants/{tenant_id}/hierarchy` | Path | `TenantHierarchy` | `TenantService.get_tenant_hierarchy()` | Fichiers JSON |
+| `PUT /api/tenants/{tenant_id}/stats` | `TenantStatsUpdate` | 204 | `TenantService.update_tenant_stats()` | Fichiers JSON |
+| `GET /api/tenants/user/{user_id}/tenants` | Path | Liste memberships | `TenantService.get_user_tenants()` | Fichiers JSON |
+| `GET /api/tenants/user/{user_id}/default-tenant` | Path | `{default_tenant_id, tenant}` | `TenantService.get_default_tenant_for_user()` | Fichiers JSON |
+| `POST /api/tenants/user/{user_id}/check-permission` | Query `tenant_id`, `permission` | `{has_permission}` | `TenantService.user_has_permission()` | Fichiers JSON |
+| `POST /api/tenants/initialize-defaults` | Query `created_by` | `{message, created_tenant_ids}` | `TenantService.create_tenant()` | Fichiers JSON |
+
+## Utilisateurs (`src/knowbase/api/routers/users.py`, préfixe `/api`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/users` | — | `UserListResponse` | `UserService.list_users()` | Fichier JSON `data/users` |
+| `GET /api/users/default` | — | `User` | `UserService.get_default_user()` | Fichier JSON |
+| `GET /api/users/{user_id}` | Path | `User` | `UserService.get_user()` | Fichier JSON |
+| `POST /api/users` | `UserCreate` | `User` | `UserService.create_user()` | Fichier JSON |
+| `PUT /api/users/{user_id}` | `UserUpdate` | `User` | `UserService.update_user()` | Fichier JSON |
+| `DELETE /api/users/{user_id}` | — | `{message}` | `UserService.delete_user()` | Fichier JSON |
+| `POST /api/users/{user_id}/activity` | — | `{message}` | `UserService.update_last_active()` | Fichier JSON |
+| `POST /api/users/{user_id}/set-default` | — | `User` | `UserService.set_default_user()` | Fichier JSON |
+
+## Healthchecks (`src/knowbase/api/routers/health.py`, préfixe `/api/health`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/health/` | — | Statut global (API, Qdrant, Redis, Postgres, Graphiti) | HTTPX ping interne | Qdrant (`http://qdrant:6333/health`), Graphiti services locaux |
+| `GET /api/health/tenants` | — | Stats Tenants | `TenantService.list_tenants()` | Fichiers JSON |
+| `GET /api/health/graphiti` | — | Statut Graphiti (Neo4j, Postgres, service) | HTTPX | Services Graphiti locaux |
+| `GET /api/health/quick` | — | Ping rapide | — | — |
+
+## Graphiti (integration directe, `src/knowbase/api/routers/graphiti.py`, préfixe `/api/graphiti`)
+
+Tous ces endpoints sont `async` et passent par `GraphitiTenantManager` (singleton initialisé à la demande).
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/graphiti/health` | — | Statut minimal | Lecture config Graphiti | Variables d’environnement Graphiti |
+| `GET /api/graphiti/health-full` | — | Statut complet (store) | `GraphitiTenantManager.store.health_check()` | Graphiti store (Neo4j, Postgres) |
+| `POST /api/graphiti/episodes` | `EpisodeCreate` | `{episode_uuid, ...}` | `GraphitiTenantManager.isolate_tenant_data(action="create_episode")` | Graphiti store, isolation multi-tenant |
+| `POST /api/graphiti/facts` | `FactCreate` | `{fact_uuid, ...}` | `GraphitiTenantManager.isolate_tenant_data(action="create_fact")` | Graphiti store |
+| `GET /api/graphiti/facts` | Query `query`, `group_id`, `status_filter`, `limit` | `{facts}` | `GraphitiTenantManager.isolate_tenant_data` ou `store.search_facts()` | Graphiti store |
+| `POST /api/graphiti/relations` | `RelationCreate` | `{relation_id, ...}` | `GraphitiTenantManager.store.create_relation()` | Graphiti store |
+| `POST /api/graphiti/subgraph` | `SubgraphRequest` | `{subgraph}` | `GraphitiTenantManager.isolate_tenant_data()` | Graphiti store |
+| `GET /api/graphiti/memory/{group_id}` | Path + `limit` | `{memory}` | `GraphitiTenantManager.isolate_tenant_data(action="get_memory")` | Graphiti store |
+| `POST /api/graphiti/tenants` | `TenantCreate` | `{message, tenant}` | `GraphitiTenantManager.create_tenant()` | Graphiti store |
+| `GET /api/graphiti/tenants` | — | `{tenants}` | `GraphitiTenantManager.list_tenants()` | Graphiti store |
+| `GET /api/graphiti/tenants/{group_id}` | Path | `{tenant}` | `GraphitiTenantManager.get_tenant_info()` | Graphiti store |
+| `DELETE /api/graphiti/tenants/{group_id}` | Path + `confirm` | `{message}` | `GraphitiTenantManager.delete_tenant()` | Graphiti store |
+
+## Knowledge Graph utilisateur/corporate (`src/knowbase/api/routers/knowledge_graph.py`, préfixe `/api`)
+
+Ces endpoints se basent sur `UserKnowledgeGraphService` qui choisit dynamiquement le groupe (corporate ou personnel) via `UserContext`.
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `GET /api/knowledge-graph/health` | — | `{status, mode, group_id, stats}` | `UserKnowledgeGraphService.get_user_stats()` | Graphiti store |
+| `POST /api/knowledge-graph/entities` | `EntityCreate` | `EntityResponse` | `UserKnowledgeGraphService.create_entity_for_user()` | Graphiti store, cache en mémoire |
+| `GET /api/knowledge-graph/entities/{entity_id}` | Path | `EntityResponse` | `UserKnowledgeGraphService.get_entity_for_user()` | Graphiti store |
+| `POST /api/knowledge-graph/relations` | `RelationCreate` | `RelationResponse` | `UserKnowledgeGraphService.create_relation_for_user()` | Graphiti store |
+| `GET /api/knowledge-graph/relations` | Query `entity_id`, `relation_type`, `limit` | `List[RelationResponse]` | `UserKnowledgeGraphService.list_relations_for_user()` | Graphiti store |
+| `DELETE /api/knowledge-graph/relations/{relation_id}` | Path | `{status, message}` | `UserKnowledgeGraphService.delete_relation_for_user()` | Graphiti store |
+| `POST /api/knowledge-graph/subgraph` | `SubgraphRequest` | `SubgraphResponse` | `UserKnowledgeGraphService.get_subgraph_for_user()` | Graphiti store |
+| `GET /api/knowledge-graph/stats` | — | `KnowledgeGraphStats` | `UserKnowledgeGraphService.get_user_stats()` | Graphiti store |
+
+## Facts Governance (`src/knowbase/api/routers/facts_governance.py`, préfixe `/api/facts`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `POST /api/facts` | `FactCreate` | `FactResponse` | `FactsGovernanceService.create_fact()` (avec `detect_conflicts`) | Graphiti store (via service), stockage JSON | 
+| `GET /api/facts` | Query filtres | `FactsListResponse` | `FactsGovernanceService.list_facts()` | Graphiti store |
+| `GET /api/facts/{fact_id}` | Path | `FactResponse` | `FactsGovernanceService.get_fact()` | Graphiti store |
+| `PUT /api/facts/{fact_id}/approve` | `FactApprovalRequest` | `FactResponse` | `FactsGovernanceService.approve_fact()` | Graphiti store |
+| `PUT /api/facts/{fact_id}/reject` | `FactRejectionRequest` | `FactResponse` | `FactsGovernanceService.reject_fact()` | Graphiti store |
+| `GET /api/facts/conflicts/list` | — | `ConflictsListResponse` | `FactsGovernanceService.get_conflicts()` | Graphiti store + règles métiers |
+| `GET /api/facts/timeline/{entity_id}` | Path | `FactTimelineResponse` | `FactsGovernanceService.get_timeline()` | Graphiti store |
+| `DELETE /api/facts/{fact_id}` | Path | 204 | `FactsGovernanceService.reject_fact()` (soft delete) | Graphiti store |
+| `GET /api/facts/stats/overview` | — | `FactStats` | `FactsGovernanceService.get_stats()` | Graphiti store |
+
+## Facts Intelligence (`src/knowbase/api/routers/facts_intelligence.py`, préfixe `/api/facts/intelligence`)
+
+| Méthode & chemin | Requête | Réponse | Services internes | Dépendances externes |
+| --- | --- | --- | --- | --- |
+| `POST /api/facts/intelligence/confidence-score` | `ConfidenceScoreRequest` | `ConfidenceScoreResponse` | `FactsIntelligenceService.calculate_confidence_score()` + `FactsGovernanceService.list_facts()` | LLMRouter (OpenAI/Anthropic) |
+| `POST /api/facts/intelligence/suggest-resolution/{fact_uuid}` | Path + body `FactCreate` reconstruit | `{suggestions}` | `FactsIntelligenceService.suggest_conflict_resolutions()` | LLMRouter |
+| `POST /api/facts/intelligence/detect-patterns` | `PatternsRequest` | `PatternsResponse` | `FactsIntelligenceService.detect_patterns_and_anomalies()` | LLMRouter (pour analyses), données Graphiti |
+| `GET /api/facts/intelligence/metrics` | Query `time_window_days` | `MetricsResponse` | `FactsIntelligenceService.calculate_governance_metrics()` | Données Facts |
+| `GET /api/facts/intelligence/alerts` | Query `severity` | `{alerts, total, by_severity}` | `FactsIntelligenceService` + `FactsGovernanceService.get_conflicts()` | LLMRouter pour recommandations |
+
+Ce catalogue couvre l’intégralité des routes montées par l’application FastAPI. Pour les détails de logique métier, reportez-vous à `MODULES.md` et au registre machine `registry.json`.

--- a/documentation/EXECUTION_FLOW.md
+++ b/documentation/EXECUTION_FLOW.md
@@ -1,0 +1,146 @@
+# Flux d’exécution majeurs
+
+Ce document décrit les principaux workflows de Knowbase, du chargement d’un document à la génération de réponses et à la gestion du graph de connaissances. Chaque flux inclut un diagramme Mermaid synthétisant les étapes.
+
+## 1. Ingestion documentaire (PPTX/PDF/Excel)
+
+```mermaid
+sequenceDiagram
+    participant UI as UI / CLI
+    participant API as POST /dispatch
+    participant Redis as Redis Queue
+    participant Worker as RQ Worker
+    participant Pipeline as Pipelines ingestion
+    participant Qdrant as Qdrant
+    participant Storage as File Storage
+    participant History as Redis Import History
+
+    UI->>API: FormData(action_type=ingest, file, meta)
+    API->>API: handle_dispatch()
+    API->>History: add_import_record(uid,...)
+    API->>Redis: enqueue_*_ingestion(job_id=uid)
+    Redis-->>Worker: Job message
+    Worker->>History: mark_job_as_processing()
+    Worker->>Pipeline: process_pptx/process_pdf/process_excel
+    Pipeline->>Storage: Enregistrement (slides, thumbnails, docs_done)
+    Pipeline->>Qdrant: upsert embeddings
+    Pipeline->>History: update_import_status(status=completed, chunks)
+    Worker-->>History: update progress + heartbeat
+    UI<<--API: {status:"queued", uid}
+    UI->>API: GET /api/status/{uid}
+    API->>Redis: fetch_job(uid)
+    API->>History: get status + enrichissement
+    API-->>UI: {status:"processing"|"done", details}
+```
+
+- `handle_dispatch()` bascule entre la recherche immédiate et l’ingestion. Pour les imports, il écrit le fichier dans `docs_in`, sauvegarde les métadonnées, enregistre l’événement dans Redis (`RedisImportHistoryService`) et pousse un job RQ (`enqueue_pptx_ingestion`, `enqueue_pdf_ingestion`, `enqueue_excel_ingestion`).
+- Le worker (`ingestion.queue.worker`) réchauffe les clients (OpenAI, Qdrant) puis traite les jobs via `jobs.py`. Chaque pipeline (PPTX/PDF/Excel) gère l’extraction, la conversion en images, l’appel LLM (résumés, métadonnées), la vectorisation et la persistance dans Qdrant.
+- Les mises à jour d’état (progression, heartbeat) sont injectées dans `job.meta` et répliquées dans l’historique Redis pour l’UI.
+
+## 2. Remplissage automatique RFP Excel
+
+```mermaid
+flowchart TD
+    A[Upload Excel RFP] --> B(handle_excel_rfp_fill)
+    B --> C{Meta file?}
+    C -- oui --> D[Enregistrer meta fournie]
+    C -- non --> E[Générer meta par défaut]
+    B --> F[Canonicalisation solution via LLM]
+    B --> G[enqueue_fill_excel job]
+    G --> H[Worker fill_excel_job]
+    H --> I[smart_fill_excel_pipeline]
+    I --> J[Analyse onglets & questions]
+    J --> K[Recherche Qdrant + synthèse LLM]
+    K --> L[Écriture réponses dans Excel]
+    L --> M[Déplacement vers presentations_dir]
+    M --> N[Mise à jour import history (chunks_filled)]
+    N --> O[Endpoint /api/downloads/filled-rfp/{uid}]
+```
+
+- `handle_excel_rfp_fill()` prépare l’UID, stocke fichier & métadonnées, tente de canonicaliser la solution via OpenAI si fournie, puis enfile `fill_excel_job`.
+- `smart_fill_excel_pipeline.main()` lit l’Excel, identifie les colonnes question/réponse, interroge Qdrant (`search_documents` ou pipelines dédiés) et remplit les cellules en utilisant les chunks les plus pertinents et des synthèses LLM.
+- Le résultat est déposé dans `presentations_dir` avec suffixe `_filled.xlsx` et devient téléchargeable.
+
+## 3. Recherche sémantique
+
+```mermaid
+sequenceDiagram
+    participant Client as Frontend
+    participant API as POST /search
+    participant Emb as SentenceTransformer
+    participant Qdrant as Qdrant
+    participant Rerank as rerank_chunks()
+    participant LLM as synthesize_response()
+
+    Client->>API: SearchRequest(question, solution?)
+    API->>Emb: encode(question)
+    Emb-->>API: query_vector
+    API->>Qdrant: search(collection, vector, filters)
+    Qdrant-->>API: hits (payload + score)
+    API->>Rerank: rerank_chunks(question, hits)
+    Rerank-->>API: reranked_hits
+    API->>LLM: synthesize_response(question, reranked_hits)
+    LLM-->>API: answer markdown + reasoning
+    API-->>Client: {results, synthesis, status}
+```
+
+- Les résultats incluent les liens statiques (`/static/slides`, `/static/presentations`) construits via `PUBLIC_URL` et le markdown généré par `_build_markdown_from_results()`.
+- Le reranking (CrossEncoder) améliore la pertinence avant la synthèse LLM.
+
+## 4. Knowledge Graph multi-tenant
+
+```mermaid
+sequenceDiagram
+    participant Client as Frontend / Agent
+    participant API as /api/knowledge-graph/*
+    participant Middleware as UserContextMiddleware
+    participant Service as UserKnowledgeGraphService
+    participant Manager as GraphitiTenantManager
+    participant Graphiti as Graphiti Store
+
+    Client->>API: Request (headers X-User-ID, X-Group-ID)
+    API->>Middleware: extraire contexte
+    Middleware-->>API: {user_id, group_id, is_personal_kg}
+    API->>Service: *for_user(request,...)*
+    Service->>Service: _ensure_user_group_initialized()
+    Service->>Manager: create/list/get tenant (if needed)
+    Manager->>Graphiti: set_group(group_id)
+    Service->>Graphiti: create_entity / create_relation / get_subgraph
+    Graphiti-->>Service: payload + metadata
+    Service-->>API: Response Pydantic (EntityResponse, etc.)
+    API-->>Client: JSON contextualisé (mode corporate ou personnel)
+```
+
+- Lors du premier appel personnel, `_ensure_user_group_initialized()` crée un groupe dédié (`user_{id}`), provisionne un schéma de base (entité Profile) et met à jour les métadonnées utilisateur.
+- Les caches `_ENTITY_CACHE` et `_RELATION_CACHE` conservent les créations récentes pour pallier les latences Graphiti tout en respectant le `group_id` courant.
+
+## 5. Gouvernance des facts + intelligence IA
+
+```mermaid
+flowchart TD
+    A[POST /api/facts] --> B[UserContext -> set_group]
+    B --> C[detect_conflicts]
+    C --> D[create_fact -> status proposed]
+    D --> E[Conflicts?]
+    E -- oui --> F[ConflictsListResponse]
+    E -- non --> G[FactResponse]
+    D --> H[Waiting for approval]
+    H --> I[PUT /api/facts/{id}/approve]
+    I --> J[approve_fact -> status approved]
+    H --> K[PUT /api/facts/{id}/reject]
+    K --> L[reject_fact -> status rejected]
+
+    subgraph Intelligence IA
+        M[POST /api/facts/intelligence/confidence-score]
+        N[POST /api/facts/intelligence/detect-patterns]
+        O[GET /api/facts/intelligence/alerts]
+    end
+
+    D --> M
+    D --> N
+    C --> O
+```
+
+- `FactsGovernanceService` manipule les faits dans Graphiti (ou caches transitoires) et maintient un audit trail (statuts, conflits). Les endpoints d’intelligence enrichissent ce processus via LLM (`FactsIntelligenceService`) pour scorer la confiance, suggérer des résolutions et détecter des tendances.
+
+Ces diagrammes couvrent les chemins critiques. Les interactions détaillées (classes, fonctions) sont documentées dans `MODULES.md` et `registry.json`.

--- a/documentation/MODULES.md
+++ b/documentation/MODULES.md
@@ -1,0 +1,155 @@
+# Référence des modules Python
+
+Chaque tableau ci-dessous liste les fichiers Python du projet avec leur rôle, les fonctions/classes majeures, leurs dépendances clés et les effets de bord (I/O, réseau, stockage). Les modules de tests (`tests/`, `app/tests/`) sont regroupés en fin de document pour clarté.
+
+## `src/knowbase/api`
+
+### Racine & infrastructure
+
+| Module | Rôle | Fonctions / classes clés | Dépendances | Entrées / effets de bord |
+| --- | --- | --- | --- | --- |
+| `src/knowbase/api/__init__.py` | Export des routers/services pour usage externe | définit `__all__` | — | — |
+| `src/knowbase/api/main.py` | Création de l’app FastAPI, montage statique, inclusion routers | `create_app()` | FastAPI, `configure_logging`, `get_settings`, `warm_clients`, `StaticFiles`, routers | Lit fichiers `openapi.json`, monte dossiers `/static/*` |
+| `src/knowbase/api/dependencies.py` | Fabrique les dépendances globales (settings, logging, warm clients) | `get_settings()`, `configure_logging()`, `warm_clients()` | `knowbase.config.settings`, `knowbase.common.clients` | Charge env vars, configure Loguru |
+
+### Middleware & contexte
+
+| Module | Rôle | Fonctions / classes clés | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `middleware/__init__.py` | Export du middleware | `__all__` | — | — |
+| `middleware/user_context.py` | Injecte le contexte multi-tenant dans la requête | `UserContextMiddleware`, `get_user_context()` | FastAPI, `contextvars` | Lit headers HTTP, stocke dans `ContextVar` |
+
+### Schémas Pydantic
+
+| Module | Rôle | Objets principaux | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `schemas/search.py` | DTO recherche | `SearchRequest`, `SearchResult`, `SearchResponse` | Pydantic | — |
+| `schemas/knowledge_graph.py` | DTO KG | `EntityCreate`, `EntityResponse`, `Relation*`, `SubgraphRequest`, `KnowledgeGraphStats`, `RelationType` | Enum, datetime | — |
+| `schemas/tenant.py` | DTO Tenants | `Tenant`, `TenantCreate`, `TenantUpdate`, `TenantHierarchy`, `TenantStats` | Pydantic | — |
+| `schemas/user.py` | DTO utilisateurs | `User`, `UserCreate`, `UserUpdate`, `UserListResponse` | datetime | — |
+| `schemas/facts_governance.py` | DTO facts | `FactCreate`, `FactResponse`, `FactUpdate`, `FactFilters`, `FactStatus`, `ConflictsListResponse`, `FactStats` | Enum, datetime | — |
+| `schemas/__init__.py` | regroupe exports | `__all__` | — | — |
+
+### Routers HTTP
+
+| Module | Rôle | Endpoints clés | Services utilisés | Effets |
+| --- | --- | --- | --- | --- |
+| `routers/search.py` | Recherche vectorielle | `POST /search`, `GET /solutions` | `search_documents`, `get_available_solutions`, clients Qdrant/embeddings | Appels Qdrant |
+| `routers/ingest.py` | Ingestion & RFP | `/dispatch`, `/documents/upload-excel-qa`, `/documents/fill-excel-rfp`, `/documents/analyze-excel` | `handle_dispatch`, `handle_excel_qa_upload`, `handle_excel_rfp_fill`, `analyze_excel_file` | Enfile jobs RQ, lit fichiers upload |
+| `routers/status.py` | Suivi de job | `GET /api/status/{uid}` | `job_status` | Lit Redis Queue + import history |
+| `routers/imports.py` | Historique imports | `GET /history`, `GET /active`, `POST /sync`, `POST /cleanup`, `DELETE /{uid}/delete` | `RedisImportHistoryService`, `delete_import_completely` | Accès Redis DB1, Qdrant, filesystem |
+| `routers/sap_solutions.py` | Dictionnaire SAP | `GET /`, `POST /resolve`, `GET /search/{query}`, `GET /with-chunks` | `SAPSolutionsManager`, Qdrant | Lecture YAML, appels LLM |
+| `routers/downloads.py` | Téléchargements | `GET /filled-rfp/{uid}`, `GET /import-files/{uid}` | `RedisImportHistoryService` | Sert des fichiers depuis `presentations_dir`, `docs_*` |
+| `routers/token_analysis.py` | Monitoring LLM | `/stats`, `/estimate-deck`, `/compare-providers`, `/cost-by-task`, `/pricing`, `/reset`, `/sagemaker-savings` | `TokenTracker` | Calculs internes |
+| `routers/tenants.py` | Gestion Tenants | CRUD, stats, permissions | `TenantService` | Lecture/écriture JSON sur disque |
+| `routers/users.py` | Gestion utilisateurs | CRUD, activité, set default | `UserService` | Lecture/écriture JSON |
+| `routers/health.py` | Health global/Graphiti | `/`, `/tenants`, `/graphiti`, `/quick` | `TenantService`, HTTPX | Ping Qdrant, Graphiti, lit fichiers |
+| `routers/graphiti.py` | API directe Graphiti | Episodes, facts, relations, subgraph, tenants | `GraphitiTenantManager`, `GraphitiStore` | Appels Neo4j/Postgres via Graphiti, isolation par tenant |
+| `routers/knowledge_graph.py` | KG multi-tenant | Health, entités, relations, subgraphs, stats | `UserKnowledgeGraphService`, `UserContext` | Appels Graphiti |
+| `routers/facts_governance.py` | Gouvernance facts | CRUD, conflicts, timeline, stats | `FactsGovernanceService`, `UserContext` | Graphiti, caches JSON |
+| `routers/facts_intelligence.py` | Analytique facts | Confidence, patterns, metrics, alerts | `FactsIntelligenceService`, `FactsGovernanceService` | Appels LLM, analyses locales |
+| `routers/knowledge_graph.py` | (voir ci-dessus) | — | — | — |
+| `routers/__init__.py` | Exports routers | liste `__all__` | — | — |
+
+### Services métier
+
+| Module | Rôle | Fonctions/classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `services/ingestion.py` | Orchestration ingestion & RFP | `handle_dispatch`, `handle_excel_qa_upload`, `handle_excel_rfp_fill`, `analyze_excel_file`, helpers | Redis history, Qdrant, OpenAI, pandas, openpyxl, filesystem | Sauvegarde fichiers, enfile jobs RQ, canonicalisation LLM |
+| `services/search.py` | Recherche + synthèse | `search_documents`, `get_available_solutions`, `build_response_payload` | Qdrant, SentenceTransformer, reranker, `synthesize_response` | Appels Qdrant, LLM |
+| `services/status.py` | Suivi job | `job_status` | RQ jobs, Redis history | Lit / met à jour Redis |
+| `services/import_history_redis.py` | Historique Redis | `RedisImportHistoryService` (CRUD) | redis-py, `get_settings` | Lecture/écriture Redis DB1 |
+| `services/import_deletion.py` | Suppression complète d’un import | `delete_import_completely` | Qdrant client, filesystem, Redis history | Supprime fichiers, Qdrant points, clés Redis |
+| `services/import_history.py` | (legacy file wrapper) | utilitaires d’import | Settings | — |
+| `services/synthesis.py` | Synthèse LLM pour recherche | `synthesize_response` | `LLMRouter`, OpenAI/Anthropic | Appels LLM |
+| `services/sap_solutions.py` | Dictionnaire solutions | `SAPSolutionsManager` (load/save, canonicalisation) | `LLMRouter`, YAML | Lecture/écriture YAML |
+| `services/tenant.py` | Persistence tenants | `TenantService` (CRUD, stats, permissions) | Pydantic, JSON fichiers | I/O disque (`data/tenants/*.json`) |
+| `services/user.py` | Persistence utilisateurs | `UserService` (CRUD, default user, activité) | JSON fichiers | I/O disque (`data/users.json`) |
+| `services/knowledge_graph.py` | KG corporate | `KnowledgeGraphService` | `GraphitiStore`, caches en mémoire | Appels Graphiti, maintient caches |
+| `services/user_knowledge_graph.py` | KG multi-tenant | `UserKnowledgeGraphService` | `KnowledgeGraphService`, `UserService`, `UserContext` | Crée groupes Graphiti, maj JSON utilisateurs |
+| `services/facts_governance_service.py` | Gouvernance facts | `FactsGovernanceService` | Graphiti store, caches internes, LLMRouter (pour conflits) | Appels Graphiti, persistance JSON/Graphiti |
+| `services/facts_intelligence.py` | IA gouvernance | `FactsIntelligenceService` | `LLMRouter`, `FactsGovernanceService`, analytics pandas-like | Appels LLM, calculs statistiques |
+| `services/import_history.py` | utilitaires (si présents) | Fonctions d’agrégat | Settings | — |
+| `services/__init__.py` | exports | `__all__` | — | — |
+
+## `src/knowbase/common`
+
+| Module | Rôle | Fonctions / classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `common/__init__.py` | exports | — | — | — |
+| `common/logging.py` | Setup Loguru | `setup_logging()` | Loguru, pathlib | Crée dossier logs |
+| `common/llm_router.py` | Routage LLM multi-provider | `LLMRouter`, `TaskType`, `complete`, `complete_sagemaker`, helpers | OpenAI SDK, Anthropic SDK, boto3 (optionnel), YAML config, `TokenTracker` | Appels API LLM, SageMaker, lecture config |
+| `common/token_tracker.py` | Suivi tokens & coûts | `TokenTracker`, `TokenUsage`, `ModelPricing`, helpers | dataclasses, logging | Sauvegarde optionnelle JSON log |
+| `common/clients/__init__.py` | exports clients | `get_qdrant_client`, `get_sentence_transformer`, etc. | qdrant-client, sentence-transformers, openai, anthropic | Télécharge modèles HF, connecte Qdrant |
+| `common/clients/qdrant_client.py` | Initialisation Qdrant | `get_qdrant_client`, `ensure_qdrant_collection` | qdrant-client, settings | Crée collections, connecte HTTP |
+| `common/clients/embeddings.py` | Charge SentenceTransformer | `get_sentence_transformer` | sentence-transformers, settings | Télécharge modèle dans `models_dir` |
+| `common/clients/openai_client.py` | Client OpenAI | `get_openai_client` | openai, settings | Instancie client, gère API key |
+| `common/clients/anthropic_client.py` | Client Anthropic | `get_anthropic_client`, `is_anthropic_available` | anthropic | — |
+| `common/clients/reranker.py` | Cross-encoder reranking | `get_cross_encoder`, `rerank_chunks` | sentence-transformers, numpy | Télécharge modèle reranker |
+| `common/clients/http.py` | HTTP utilitaire (Graphiti) | `HttpClient` wrapper | httpx | — |
+| `common/clients/shared_clients.py` | Cache de clients partagés | `SharedClients`, `warm_clients()` | dépendances clients | Précharge modèles/API |
+| `common/interfaces/graph_store.py` | Interface Graph store | `GraphStoreProtocol`, dataclasses `FactStatus`, etc. | typing | — |
+| `common/interfaces/__init__.py` | exports | — | — | — |
+| `common/sap/normalizer.py` | Normalisation solutions SAP | `normalize_solution_name` | regex | — |
+| `common/sap/solutions_dict.py` | Dictionnaire statique solutions | Constantes | — | — |
+| `common/sap/claims.py` | Gestion des claims SAP | Fonctions utilitaires | JSON | — |
+| `common/graphiti/config.py` | Config Graphiti | `GraphitiConfig.from_env()` | os, dataclasses | Lit env vars |
+| `common/graphiti/graphiti_store.py` | Wrapper service Graphiti | `GraphitiStore` (CRUD entités, relations, facts, health) | httpx, async, Graphiti API | Requêtes HTTP Graphiti, conversions |
+| `common/graphiti/tenant_manager.py` | Gestion multi-tenant Graphiti | `GraphitiTenantManager`, `create_tenant_manager` | `GraphitiStore`, asyncio locks | Maintient mapping groupe→store |
+| `common/graphiti/__init__.py` | exports | — | — | — |
+
+## `src/knowbase/config`
+
+| Module | Rôle | Fonctions / classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `config/settings.py` | Configuration globale | `Settings` (Pydantic BaseSettings), `get_settings()` | os, pathlib, pydantic | Lit env vars, résout chemins `data/` |
+| `config/paths.py` | Gestion chemins projet | `PROJECT_ROOT`, `DATA_DIR`, `ensure_directories()` | pathlib | Crée dossiers manquants |
+| `config/prompts_loader.py` | Chargement prompts LLM | `load_prompts`, `select_prompt`, `render_prompt` | yaml, jinja2 | Lit fichiers `config/prompts/*.yaml` |
+| `config/__init__.py` | exports | — | — | — |
+
+## `src/knowbase/ingestion`
+
+| Module | Rôle | Fonctions / classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `ingestion/__init__.py` | exports | — | — | — |
+| `ingestion/queue/__init__.py` | exports | — | — | — |
+| `ingestion/queue/connection.py` | Connexion Redis/RQ | `get_redis_connection`, `get_queue` | redis, rq | Ouvre connexion Redis |
+| `ingestion/queue/dispatcher.py` | Enqueue jobs | `enqueue_pptx_ingestion`, `enqueue_pdf_ingestion`, `enqueue_excel_ingestion`, `enqueue_fill_excel`, `fetch_job` | RQ | Ajoute jobs, enrichit meta |
+| `ingestion/queue/jobs.py` | Fonctions worker | `ingest_pptx_job`, `ingest_pdf_job`, `ingest_excel_job`, `fill_excel_job`, helpers `update_job_progress`, `mark_job_as_processing` | Pipelines, Redis history, filesystem | Lis/écrit fichiers, upsert Qdrant, update Redis |
+| `ingestion/queue/worker.py` | Worker entrypoint | `run_worker`, `warm_clients`, `main` | RQ, debugpy | Lance worker, attache debugger |
+| `ingestion/queue/__main__.py` | CLI worker | Permet `python -m knowbase.ingestion.queue` | `run_worker` | — |
+| `ingestion/pipelines/pptx_pipeline.py` | Pipeline PPTX complet | `process_pptx`, extraction slides, conversion PDF→images, prompts LLM, embeddings, upsert Qdrant | MegaParse/python-pptx, PyMuPDF, PIL, Qdrant, LLMRouter | Gère fichiers (slides, thumbnails), appelle LLM, Qdrant |
+| `ingestion/pipelines/pdf_pipeline.py` | Pipeline PDF | `process_pdf` | PyMuPDF, qdrant, SentenceTransformer | Convertit PDF, extrait texte, enregistre |
+| `ingestion/pipelines/excel_pipeline.py` | Pipeline Excel ingestion | `process_excel_rfp` | pandas, openpyxl, Qdrant | Lit onglets, génère chunks |
+| `ingestion/pipelines/fill_excel_pipeline.py` | Ancien pipeline RFP | Fonctions de remplissage | pandas, openpyxl | Manipule Excel |
+| `ingestion/pipelines/smart_fill_excel_pipeline.py` | Pipeline intelligent RFP | `main`, helpers (analyse, recherche, écriture) | pandas, openpyxl, `search_documents`, LLMRouter | Lit/écrit Excel, interroge Qdrant/LLM |
+| `ingestion/pipelines/__init__.py` | exports | — | — | — |
+| `ingestion/processors/__init__.py` | placeholder | — | — | — |
+| `ingestion/cli/*.py` | CLI maintenance | purge collections, generate thumbnails, migration, update solutions | Click/argparse, Qdrant, filesystem | Scripts standalone |
+
+## `src/knowbase/ui`
+
+| Module | Rôle | Fonctions / classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `ui/__init__.py` | exports | — | — | — |
+| `ui/streamlit_app.py` | Interface Streamlit legacy | `main()` | streamlit, pandas, services backend | Lance UI Streamlit, appels API |
+
+## Autres modules
+
+| Module | Rôle | Fonctions / classes | Dépendances | Effets |
+| --- | --- | --- | --- | --- |
+| `src/knowbase/__init__.py` | Package marker | `__version__` éventuel | — | — |
+| `app/main.py` | Entrée FastAPI conteneurisée | instancie `create_app()` | uvicorn, FastAPI | Sert l’API en mode conteneur |
+| `app/claims_utils.py` | Utilitaires assertions (Streamlit) | Fonctions de formatage claims | pandas | — |
+| `scripts/*.py` | Scripts opérationnels (import/export, validation Graphiti/Qdrant, analyse PPTX) | Fonctions `main()` spécifiques | click/argparse, services | Accèdent aux mêmes clients (Qdrant, Graphiti, filesystem) |
+| `ui/app.py` | Lancement Streamlit packagé | `main()` | streamlit | Lance UI |
+| `test_phase2_validation.py` | Script validation phases | Fonctions de test orchestré | pytest | — |
+
+## Modules de tests
+
+| Dossier | Contenu | Objectif |
+| --- | --- | --- |
+| `tests/` | Tests unitaires/integration pour le package `src/knowbase` (dependencies, settings, llm_router, ingestion, Graphiti, facts) | Valider la logique métier dans l’environnement source |
+| `app/tests/` | Copies des tests pour l’application dockerisée (`app/`) | Garantir qu’`app/main.py` reste aligné avec `src/knowbase/api` |
+
+Ce tableau constitue la carte des modules runtime. Les scripts/tests détaillés reprennent les mêmes services : reportez-vous à `registry.json` pour les signatures d’API précises.

--- a/documentation/OVERVIEW.md
+++ b/documentation/OVERVIEW.md
@@ -1,0 +1,57 @@
+# Architecture Overview
+
+Knowbase est une plateforme de gestion de connaissances SAP combinant ingestion documentaire, recherche vectorielle, gouvernance de facts et graph de connaissances multi-tenant. Cette vue d’ensemble synthétise l’architecture applicative et le rôle de chaque dossier clé.
+
+## Composants principaux
+
+| Composant | Description | Technologies | Dossiers associés |
+| --- | --- | --- | --- |
+| **API Backend** | Application FastAPI orchestrant les endpoints publics et internes. Monte les ressources statiques et instancie les dépendances (clients LLM, Qdrant, Redis). | FastAPI, Pydantic, Uvicorn | `src/knowbase/api`, `app/main.py` |
+| **Pipelines d’ingestion** | Détectent le type de document (PPTX/PDF/Excel), extraient le texte et les métadonnées, génèrent des embeddings et écrivent dans Qdrant. Lancement asynchrone via Redis Queue. | Python, RQ, PyMuPDF, python-pptx, pandas, SentenceTransformers | `src/knowbase/ingestion` |
+| **Recherche vectorielle** | Encapsule la recherche et le reranking sur Qdrant avec synthèse de réponse LLM. | Qdrant, SentenceTransformers, OpenAI/Anthropic via `LLMRouter` | `src/knowbase/api/services/search.py`, `src/knowbase/common/clients` |
+| **Gouvernance des facts** | API et services pour créer/valider/rejeter des facts, détecter les conflits et suivre les métriques de gouvernance. | Graphiti store, LLMRouter, Redis, JSON stores | `src/knowbase/api/routers/facts_*`, `src/knowbase/api/services/facts_*` |
+| **Knowledge Graph** | Couche multi-tenant sur Graphiti (Neo4j + services auxiliaires) pour les entités/relations corporate et personnelles. | Graphiti, Neo4j, PostgreSQL (Graphiti), FastAPI | `src/knowbase/api/routers/knowledge_graph.py`, `src/knowbase/api/services/user_knowledge_graph.py`, `src/knowbase/common/graphiti` |
+| **Gestion multi-tenant & utilisateurs** | Services persistant la hiérarchie de tenants (fichiers JSON) et la configuration utilisateur (fichiers + mémoire). Fournit endpoints de gestion. | Pydantic, fichiers JSON, FastAPI | `src/knowbase/api/routers/tenants.py`, `src/knowbase/api/services/tenant.py`, `src/knowbase/api/routers/users.py` |
+| **Tracking des coûts LLM** | Endpoints de suivi/estimation des tokens et coûts, comparaison de providers et scénarios de migration. | TokenTracker, OpenAI/Anthropic tarifs, calculs Python | `src/knowbase/api/routers/token_analysis.py`, `src/knowbase/common/token_tracker.py` |
+| **Interfaces utilisateur** | Frontend Next.js pour la recherche/chat, UI Streamlit historique pour les usages internes, scripts CLI. | Next.js, Chakra UI, Streamlit | `frontend/`, `ui/`, `src/knowbase/ui/` |
+
+## Cartographie des dossiers
+
+- `app/` – image Docker légère exposant FastAPI via `app/main.py` (réutilise `src/knowbase/api`).
+- `src/knowbase/api/` – points d’entrée HTTP (`routers`), dépendances globales (`dependencies.py`), modèles Pydantic (`schemas`), logique métier (`services`), middleware (`middleware`).
+- `src/knowbase/common/` – clients externes (OpenAI, Anthropic, Qdrant), routeur LLM, outils de logging, normalisation SAP, intégration Graphiti.
+- `src/knowbase/config/` – settings Pydantic, gestion des chemins, chargement des prompts.
+- `src/knowbase/ingestion/` – pipelines et workers RQ (dispatcher, jobs, worker), CLI utilitaires pour gérer Qdrant et générer des vignettes.
+- `src/knowbase/ui/` – application Streamlit alternative reposant sur les mêmes services backend.
+- `frontend/` et `ui/` – clients web (Next.js) et Streamlit packagés séparément.
+- `scripts/` – scripts ponctuels d’import/export, validation Graphiti et Qdrant.
+- `tests/`, `app/tests/` – suites de tests unitaires et d’intégration (identiques pour l’application packagée et le module source).
+
+## Topologie runtime
+
+```text
+┌───────────┐     ┌───────────────┐     ┌────────────┐
+│ Frontends │ --> │ FastAPI / RQ  │ --> │ Pipelines  │
+└───────────┘     │  (Docker)    │     │ ingestion  │
+      │           └─────┬────────┘     └────┬───────┘
+      │                 │                  │
+      ▼                 ▼                  ▼
+┌─────────────┐   ┌──────────────┐   ┌────────────┐
+│ Redis (RQ)  │   │ Qdrant       │   │ Graphiti   │
+└─────────────┘   │ Vector store │   │ (Neo4j+DB) │
+                  └──────────────┘   └────────────┘
+```
+
+- Les requêtes HTTP atteignent FastAPI (`create_app`) qui configure CORS, middleware `UserContext`, et instancie les clients partagés (`warm_clients`).
+- Les imports volumineux sont insérés dans une queue Redis (`enqueue_*`) afin d’être traités par les workers RQ (`ingestion.queue.worker`).
+- Qdrant stocke les embeddings (collections principale et `rfp_qa`), Graphiti gère les entités/relations, Redis DB1 conserve l’historique des imports, et le stockage disque (`/data`) accueille les fichiers normalisés, slides, thumbnails et exports.
+
+## Interactions notables
+
+- **LLMRouter** sélectionne dynamiquement le modèle LLM selon la tâche (vision, résumé, canonicalisation). Il trace les coûts via `TokenTracker`.
+- **GraphitiTenantManager** assure l’isolation des données Knowledge Graph : endpoints `graphiti` et `knowledge-graph` passent par un gestionnaire singleton qui crée/configure les groupes Neo4j.
+- **Import History** : `RedisImportHistoryService` suit l’état des jobs et expose des endpoints d’observabilité (`/api/imports/*`, `/api/status/{uid}`).
+- **SAP Solutions** : un gestionnaire YAML enrichi par LLM maintient le dictionnaire des solutions et expose des API de recherche/résolution.
+- **Facts Governance/Intelligence** : les endpoints `/api/facts` et `/api/facts/intelligence` combinent validations métiers, détection de conflits et recommandations IA.
+
+Cette architecture découple clairement la couche API, les pipelines batch, les stores de connaissances (Qdrant, Graphiti) et les interfaces clients, facilitant l’extension de chaque sous-système.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,21 @@
+# Documentation Guide
+
+Bienvenue dans le dossier `/documentation`. Il complète le dossier historique `/doc` en offrant une vue exhaustive et structurée de Knowbase pour les lecteurs humains et les IA génératives.
+
+## Structure
+
+- `OVERVIEW.md` – architecture globale de la plateforme, description des principaux composants et cartographie des dossiers.
+- `BACKEND_APIS.md` – catalogue détaillé de toutes les routes FastAPI, avec schémas de requêtes/réponses, services sous-jacents et dépendances externes.
+- `EXECUTION_FLOW.md` – scénarios d’exécution majeurs illustrés par des diagrammes Mermaid (ingestion, recherche, Graphiti, gouvernance des facts, etc.).
+- `MODULES.md` – tableau de référence listant chaque module Python avec son rôle, ses fonctions clés, ses dépendances et ses effets de bord.
+- `registry.json` – registre exploitable par une IA décrivant inputs/outputs/dépendances de chaque fonction ou endpoint exposé.
+- `AI_GUIDE.md` – conventions et bonnes pratiques pour les IA génératives amenées à étendre le projet.
+
+## Comment utiliser cette documentation
+
+1. **Prise en main rapide** : commencez par `OVERVIEW.md` pour comprendre l’architecture macro et identifier les sous-systèmes pertinents.
+2. **Implémentation ou debug backend** : utilisez `BACKEND_APIS.md` et `EXECUTION_FLOW.md` pour suivre la circulation des données depuis l’API jusqu’aux pipelines d’ingestion ou au graph de connaissances.
+3. **Analyse détaillée** : consultez `MODULES.md` pour localiser les fonctions/classes nécessaires et repérer les effets de bord (accès disque, Qdrant, Redis, etc.).
+4. **Automatisation/IA** : pointez votre agent sur `registry.json` et `AI_GUIDE.md` pour récupérer rapidement les signatures, conventions et dépendances critiques.
+
+Chaque fichier est maintenu en Markdown/JSON standard pour favoriser l’ingestion automatique, l’indexation vectorielle ou la génération de documentation dynamique.

--- a/documentation/registry.json
+++ b/documentation/registry.json
@@ -1,0 +1,1499 @@
+[
+  {
+    "name": "create_app",
+    "path": "src/knowbase/api/main.py",
+    "purpose": "Initialise FastAPI, configure CORS/static files et monte les routers",
+    "inputs": [],
+    "outputs": [
+      "FastAPI"
+    ],
+    "calls": [
+      "knowbase.api.dependencies.get_settings",
+      "knowbase.api.dependencies.configure_logging",
+      "knowbase.api.dependencies.warm_clients",
+      "fastapi.middleware.cors.CORSMiddleware",
+      "knowbase.api.middleware.user_context.UserContextMiddleware",
+      "fastapi.staticfiles.StaticFiles"
+    ]
+  },
+  {
+    "name": "search",
+    "path": "src/knowbase/api/routers/search.py",
+    "purpose": "Endpoint POST /search pour la recherche vectorielle",
+    "inputs": [
+      "SearchRequest"
+    ],
+    "outputs": [
+      "dict(status, results, synthesis)"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.common.clients.get_qdrant_client",
+      "knowbase.common.clients.get_sentence_transformer",
+      "knowbase.api.services.search.search_documents"
+    ]
+  },
+  {
+    "name": "get_solutions",
+    "path": "src/knowbase/api/routers/search.py",
+    "purpose": "Endpoint GET /solutions pour récupérer les solutions disponibles",
+    "inputs": [],
+    "outputs": [
+      "List[str]"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.common.clients.get_qdrant_client",
+      "knowbase.api.services.search.get_available_solutions"
+    ]
+  },
+  {
+    "name": "search_documents",
+    "path": "src/knowbase/api/services/search.py",
+    "purpose": "Recherche dans Qdrant, reranking et synthèse",
+    "inputs": [
+      "question",
+      "qdrant_client",
+      "embedding_model",
+      "settings",
+      "solution"
+    ],
+    "outputs": [
+      "dict(status, results, synthesis)"
+    ],
+    "calls": [
+      "qdrant_client.search",
+      "knowbase.common.clients.rerank_chunks",
+      "knowbase.api.services.synthesis.synthesize_response"
+    ]
+  },
+  {
+    "name": "get_available_solutions",
+    "path": "src/knowbase/api/services/search.py",
+    "purpose": "Parcourt Qdrant pour lister les solutions référencées",
+    "inputs": [
+      "qdrant_client",
+      "settings"
+    ],
+    "outputs": [
+      "List[str]"
+    ],
+    "calls": [
+      "qdrant_client.scroll"
+    ]
+  },
+  {
+    "name": "dispatch_action",
+    "path": "src/knowbase/api/routers/ingest.py",
+    "purpose": "Endpoint POST /dispatch pour recherche ou ingestion",
+    "inputs": [
+      "Request",
+      "action_type",
+      "document_type",
+      "question",
+      "UploadFile file",
+      "meta"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.ingestion.handle_dispatch"
+    ]
+  },
+  {
+    "name": "handle_dispatch",
+    "path": "src/knowbase/api/services/ingestion.py",
+    "purpose": "Orchestre la recherche directe ou la mise en file d’un import",
+    "inputs": [
+      "request",
+      "action_type",
+      "document_type",
+      "question",
+      "file",
+      "meta",
+      "settings",
+      "logger"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.clients.get_qdrant_client",
+      "knowbase.common.clients.get_sentence_transformer",
+      "knowbase.api.services.search.search_documents",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service",
+      "knowbase.ingestion.queue.enqueue_pptx_ingestion",
+      "knowbase.ingestion.queue.enqueue_pdf_ingestion",
+      "knowbase.ingestion.queue.enqueue_excel_ingestion",
+      "knowbase.ingestion.queue.enqueue_fill_excel"
+    ]
+  },
+  {
+    "name": "upload_excel_qa",
+    "path": "src/knowbase/api/routers/ingest.py",
+    "purpose": "Endpoint POST /documents/upload-excel-qa",
+    "inputs": [
+      "UploadFile file",
+      "UploadFile meta_file"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.ingestion.handle_excel_qa_upload"
+    ]
+  },
+  {
+    "name": "handle_excel_qa_upload",
+    "path": "src/knowbase/api/services/ingestion.py",
+    "purpose": "Persist l’Excel Q/A et programme l’ingestion",
+    "inputs": [
+      "file",
+      "meta_file",
+      "settings",
+      "logger"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service",
+      "knowbase.ingestion.queue.enqueue_excel_ingestion"
+    ]
+  },
+  {
+    "name": "fill_excel_rfp",
+    "path": "src/knowbase/api/routers/ingest.py",
+    "purpose": "Endpoint POST /documents/fill-excel-rfp",
+    "inputs": [
+      "UploadFile file",
+      "UploadFile meta_file"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.ingestion.handle_excel_rfp_fill"
+    ]
+  },
+  {
+    "name": "handle_excel_rfp_fill",
+    "path": "src/knowbase/api/services/ingestion.py",
+    "purpose": "Met en file le remplissage intelligent d’un RFP",
+    "inputs": [
+      "file",
+      "meta_file",
+      "settings",
+      "logger"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.ingestion.get_canonical_solution_name",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service",
+      "knowbase.ingestion.queue.enqueue_fill_excel"
+    ]
+  },
+  {
+    "name": "analyze_excel",
+    "path": "src/knowbase/api/routers/ingest.py",
+    "purpose": "Endpoint POST /documents/analyze-excel",
+    "inputs": [
+      "UploadFile file"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.ingestion.analyze_excel_file"
+    ]
+  },
+  {
+    "name": "analyze_excel_file",
+    "path": "src/knowbase/api/services/ingestion.py",
+    "purpose": "Analyse structurelle d’un classeur Excel",
+    "inputs": [
+      "file",
+      "settings",
+      "logger"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "openpyxl.load_workbook",
+      "pandas.read_excel"
+    ]
+  },
+  {
+    "name": "get_status",
+    "path": "src/knowbase/api/routers/status.py",
+    "purpose": "Endpoint GET /api/status/{uid}",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.status.job_status"
+    ]
+  },
+  {
+    "name": "job_status",
+    "path": "src/knowbase/api/services/status.py",
+    "purpose": "Lit un job RQ et synchronise l’historique Redis",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.ingestion.queue.fetch_job",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "get_import_history",
+    "path": "src/knowbase/api/routers/imports.py",
+    "purpose": "Endpoint GET /api/imports/history",
+    "inputs": [
+      "limit"
+    ],
+    "outputs": [
+      "List[Dict]"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "get_active_imports",
+    "path": "src/knowbase/api/routers/imports.py",
+    "purpose": "Endpoint GET /api/imports/active",
+    "inputs": [],
+    "outputs": [
+      "List[Dict]"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "sync_orphaned_jobs",
+    "path": "src/knowbase/api/routers/imports.py",
+    "purpose": "Endpoint POST /api/imports/sync",
+    "inputs": [],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "cleanup_old_imports",
+    "path": "src/knowbase/api/routers/imports.py",
+    "purpose": "Endpoint POST /api/imports/cleanup",
+    "inputs": [
+      "days"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "delete_import_completely_endpoint",
+    "path": "src/knowbase/api/routers/imports.py",
+    "purpose": "Endpoint DELETE /api/imports/{uid}/delete",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.import_deletion.delete_import_completely"
+    ]
+  },
+  {
+    "name": "delete_import_completely",
+    "path": "src/knowbase/api/services/import_deletion.py",
+    "purpose": "Supprime fichiers, chunks Qdrant et historique pour un import",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service",
+      "knowbase.common.clients.get_qdrant_client",
+      "pathlib.Path.unlink"
+    ]
+  },
+  {
+    "name": "sap_get_solutions",
+    "path": "src/knowbase/api/routers/sap_solutions.py",
+    "purpose": "Endpoint GET /api/sap-solutions/",
+    "inputs": [],
+    "outputs": [
+      "SolutionsListResponse"
+    ],
+    "calls": [
+      "knowbase.api.services.sap_solutions.get_sap_solutions_manager"
+    ]
+  },
+  {
+    "name": "sap_resolve_solution",
+    "path": "src/knowbase/api/routers/sap_solutions.py",
+    "purpose": "Endpoint POST /api/sap-solutions/resolve",
+    "inputs": [
+      "SolutionResolveRequest"
+    ],
+    "outputs": [
+      "SolutionResolveResponse"
+    ],
+    "calls": [
+      "knowbase.api.services.sap_solutions.get_sap_solutions_manager"
+    ]
+  },
+  {
+    "name": "sap_search_solutions",
+    "path": "src/knowbase/api/routers/sap_solutions.py",
+    "purpose": "Endpoint GET /api/sap-solutions/search/{query}",
+    "inputs": [
+      "query"
+    ],
+    "outputs": [
+      "SolutionsListResponse"
+    ],
+    "calls": [
+      "knowbase.api.services.sap_solutions.get_sap_solutions_manager"
+    ]
+  },
+  {
+    "name": "sap_get_solutions_with_chunks",
+    "path": "src/knowbase/api/routers/sap_solutions.py",
+    "purpose": "Endpoint GET /api/sap-solutions/with-chunks",
+    "inputs": [
+      "extend_search"
+    ],
+    "outputs": [
+      "SolutionsListResponse"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.common.clients.get_qdrant_client",
+      "knowbase.api.services.sap_solutions.get_sap_solutions_manager"
+    ]
+  },
+  {
+    "name": "download_filled_rfp",
+    "path": "src/knowbase/api/routers/downloads.py",
+    "purpose": "Endpoint GET /api/downloads/filled-rfp/{uid}",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "FileResponse"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "download_import_file",
+    "path": "src/knowbase/api/routers/downloads.py",
+    "purpose": "Endpoint GET /api/downloads/import-files/{uid}",
+    "inputs": [
+      "uid"
+    ],
+    "outputs": [
+      "FileResponse"
+    ],
+    "calls": [
+      "knowbase.config.settings.get_settings",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "token_stats",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/stats",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "estimate_deck_cost",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/estimate-deck",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "compare_providers_cost",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/compare-providers",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "cost_by_task_type",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/cost-by-task",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "get_model_pricing",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/pricing",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "reset_token_tracking",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint POST /api/tokens/reset",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "estimate_sagemaker_savings",
+    "path": "src/knowbase/api/routers/token_analysis.py",
+    "purpose": "Endpoint GET /api/tokens/sagemaker-savings",
+    "inputs": [
+      "query params selon endpoint"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.token_tracker.get_token_tracker"
+    ]
+  },
+  {
+    "name": "create_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint POST /api/tenants/",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.create_tenant"
+    ]
+  },
+  {
+    "name": "list_tenants",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.list_tenants"
+    ]
+  },
+  {
+    "name": "get_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/{tenant_id}",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.get_tenant"
+    ]
+  },
+  {
+    "name": "update_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint PUT /api/tenants/{tenant_id}",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.update_tenant"
+    ]
+  },
+  {
+    "name": "delete_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint DELETE /api/tenants/{tenant_id}",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.delete_tenant"
+    ]
+  },
+  {
+    "name": "add_user_to_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint POST /api/tenants/{tenant_id}/users",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.add_user_to_tenant"
+    ]
+  },
+  {
+    "name": "get_tenant_users",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/{tenant_id}/users",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.get_tenant_users"
+    ]
+  },
+  {
+    "name": "get_tenant_hierarchy",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/{tenant_id}/hierarchy",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.get_tenant_hierarchy"
+    ]
+  },
+  {
+    "name": "update_tenant_stats",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint PUT /api/tenants/{tenant_id}/stats",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.update_tenant_stats"
+    ]
+  },
+  {
+    "name": "get_user_tenants",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/user/{user_id}/tenants",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.get_user_tenants"
+    ]
+  },
+  {
+    "name": "get_user_default_tenant",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint GET /api/tenants/user/{user_id}/default-tenant",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.get_default_tenant_for_user"
+    ]
+  },
+  {
+    "name": "check_user_permission",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint POST /api/tenants/user/{user_id}/check-permission",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.user_has_permission"
+    ]
+  },
+  {
+    "name": "initialize_default_tenants",
+    "path": "src/knowbase/api/routers/tenants.py",
+    "purpose": "Endpoint POST /api/tenants/initialize-defaults",
+    "inputs": [
+      "pydantic request / path params"
+    ],
+    "outputs": [
+      "Tenant/response dict"
+    ],
+    "calls": [
+      "TenantService.create_tenant"
+    ]
+  },
+  {
+    "name": "list_users",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint GET /api/users",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.list_users"
+    ]
+  },
+  {
+    "name": "get_default_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint GET /api/users/default",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.get_default_user"
+    ]
+  },
+  {
+    "name": "get_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint GET /api/users/{user_id}",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.get_user"
+    ]
+  },
+  {
+    "name": "create_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint POST /api/users",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.create_user"
+    ]
+  },
+  {
+    "name": "update_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint PUT /api/users/{user_id}",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.update_user"
+    ]
+  },
+  {
+    "name": "delete_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint DELETE /api/users/{user_id}",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.delete_user"
+    ]
+  },
+  {
+    "name": "update_user_activity",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint POST /api/users/{user_id}/activity",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.update_last_active"
+    ]
+  },
+  {
+    "name": "set_default_user",
+    "path": "src/knowbase/api/routers/users.py",
+    "purpose": "Endpoint POST /api/users/{user_id}/set-default",
+    "inputs": [
+      "params selon endpoint"
+    ],
+    "outputs": [
+      "User ou dict"
+    ],
+    "calls": [
+      "user_service.set_default_user"
+    ]
+  },
+  {
+    "name": "health_check_full",
+    "path": "src/knowbase/api/routers/health.py",
+    "purpose": "Endpoint GET /api/health/",
+    "inputs": [],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "httpx.AsyncClient",
+      "TenantService.list_tenants"
+    ]
+  },
+  {
+    "name": "health_check_tenants",
+    "path": "src/knowbase/api/routers/health.py",
+    "purpose": "Endpoint GET /api/health/tenants",
+    "inputs": [],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "TenantService.list_tenants"
+    ]
+  },
+  {
+    "name": "health_check_graphiti",
+    "path": "src/knowbase/api/routers/health.py",
+    "purpose": "Endpoint GET /api/health/graphiti",
+    "inputs": [],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "httpx.AsyncClient"
+    ]
+  },
+  {
+    "name": "health_check_quick",
+    "path": "src/knowbase/api/routers/health.py",
+    "purpose": "Endpoint GET /api/health/quick",
+    "inputs": [],
+    "outputs": [
+      "dict"
+    ],
+    "calls": []
+  },
+  {
+    "name": "graphiti_health",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/health",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.common.graphiti.config.graphiti_config"
+    ]
+  },
+  {
+    "name": "graphiti_health_full",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/health-full",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.store.health_check"
+    ]
+  },
+  {
+    "name": "create_episode",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint POST /api/graphiti/episodes",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.isolate_tenant_data"
+    ]
+  },
+  {
+    "name": "create_fact_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint POST /api/graphiti/facts",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.isolate_tenant_data"
+    ]
+  },
+  {
+    "name": "search_facts_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/facts",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.isolate_tenant_data",
+      "GraphitiTenantManager.store.search_facts"
+    ]
+  },
+  {
+    "name": "create_relation_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint POST /api/graphiti/relations",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.store.create_relation"
+    ]
+  },
+  {
+    "name": "get_subgraph_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint POST /api/graphiti/subgraph",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.isolate_tenant_data",
+      "GraphitiTenantManager.store.get_subgraph"
+    ]
+  },
+  {
+    "name": "get_memory_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/memory/{group_id}",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.isolate_tenant_data"
+    ]
+  },
+  {
+    "name": "create_tenant_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint POST /api/graphiti/tenants",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.create_tenant"
+    ]
+  },
+  {
+    "name": "list_tenants_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/tenants",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.list_tenants"
+    ]
+  },
+  {
+    "name": "get_tenant_info_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint GET /api/graphiti/tenants/{group_id}",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.get_tenant_info"
+    ]
+  },
+  {
+    "name": "delete_tenant_graphiti",
+    "path": "src/knowbase/api/routers/graphiti.py",
+    "purpose": "Endpoint DELETE /api/graphiti/tenants/{group_id}",
+    "inputs": [
+      "pydantic body / path params"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "knowbase.api.routers.graphiti.get_tenant_manager",
+      "GraphitiTenantManager.delete_tenant"
+    ]
+  },
+  {
+    "name": "kg_health",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint GET /api/knowledge-graph/health",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.get_user_stats"
+    ]
+  },
+  {
+    "name": "kg_create_entity",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint POST /api/knowledge-graph/entities",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.create_entity_for_user"
+    ]
+  },
+  {
+    "name": "kg_get_entity",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint GET /api/knowledge-graph/entities/{entity_id}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.get_entity_for_user"
+    ]
+  },
+  {
+    "name": "kg_create_relation",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint POST /api/knowledge-graph/relations",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.create_relation_for_user"
+    ]
+  },
+  {
+    "name": "kg_list_relations",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint GET /api/knowledge-graph/relations",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.list_relations_for_user"
+    ]
+  },
+  {
+    "name": "kg_delete_relation",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint DELETE /api/knowledge-graph/relations/{relation_id}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.delete_relation_for_user"
+    ]
+  },
+  {
+    "name": "kg_get_subgraph",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint POST /api/knowledge-graph/subgraph",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.get_subgraph_for_user"
+    ]
+  },
+  {
+    "name": "kg_get_stats",
+    "path": "src/knowbase/api/routers/knowledge_graph.py",
+    "purpose": "Endpoint GET /api/knowledge-graph/stats",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "UserKnowledgeGraphService.get_user_stats"
+    ]
+  },
+  {
+    "name": "create_fact",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint POST /api/facts",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.detect_conflicts",
+      "FactsGovernanceService.create_fact"
+    ]
+  },
+  {
+    "name": "list_facts",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint GET /api/facts",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.list_facts"
+    ]
+  },
+  {
+    "name": "get_fact",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint GET /api/facts/{fact_id}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_fact"
+    ]
+  },
+  {
+    "name": "approve_fact",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint PUT /api/facts/{fact_id}/approve",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.approve_fact"
+    ]
+  },
+  {
+    "name": "reject_fact",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint PUT /api/facts/{fact_id}/reject",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.reject_fact"
+    ]
+  },
+  {
+    "name": "list_conflicts",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint GET /api/facts/conflicts/list",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_conflicts"
+    ]
+  },
+  {
+    "name": "get_entity_timeline",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint GET /api/facts/timeline/{entity_id}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_timeline"
+    ]
+  },
+  {
+    "name": "delete_fact",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint DELETE /api/facts/{fact_id}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_fact",
+      "FactsGovernanceService.reject_fact"
+    ]
+  },
+  {
+    "name": "get_facts_stats",
+    "path": "src/knowbase/api/routers/facts_governance.py",
+    "purpose": "Endpoint GET /api/facts/stats/overview",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "Pydantic response"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_stats"
+    ]
+  },
+  {
+    "name": "calculate_confidence",
+    "path": "src/knowbase/api/routers/facts_intelligence.py",
+    "purpose": "Endpoint POST /api/facts/intelligence/confidence-score",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "dict ou Pydantic"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.list_facts",
+      "FactsIntelligenceService.calculate_confidence_score"
+    ]
+  },
+  {
+    "name": "suggest_conflict_resolution",
+    "path": "src/knowbase/api/routers/facts_intelligence.py",
+    "purpose": "Endpoint POST /api/facts/intelligence/suggest-resolution/{fact_uuid}",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "dict ou Pydantic"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.get_fact",
+      "FactsGovernanceService.detect_conflicts",
+      "FactsIntelligenceService.suggest_conflict_resolutions"
+    ]
+  },
+  {
+    "name": "detect_patterns",
+    "path": "src/knowbase/api/routers/facts_intelligence.py",
+    "purpose": "Endpoint POST /api/facts/intelligence/detect-patterns",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "dict ou Pydantic"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.list_facts",
+      "FactsIntelligenceService.detect_patterns_and_anomalies"
+    ]
+  },
+  {
+    "name": "get_governance_metrics",
+    "path": "src/knowbase/api/routers/facts_intelligence.py",
+    "purpose": "Endpoint GET /api/facts/intelligence/metrics",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "dict ou Pydantic"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.list_facts",
+      "FactsIntelligenceService.calculate_governance_metrics"
+    ]
+  },
+  {
+    "name": "get_governance_alerts",
+    "path": "src/knowbase/api/routers/facts_intelligence.py",
+    "purpose": "Endpoint GET /api/facts/intelligence/alerts",
+    "inputs": [
+      "Request",
+      "schemas selon endpoint"
+    ],
+    "outputs": [
+      "dict ou Pydantic"
+    ],
+    "calls": [
+      "knowbase.api.middleware.user_context.get_user_context",
+      "FactsGovernanceService.set_group",
+      "FactsGovernanceService.list_facts",
+      "FactsGovernanceService.get_conflicts",
+      "FactsIntelligenceService.calculate_governance_metrics"
+    ]
+  },
+  {
+    "name": "ingest_pptx_job",
+    "path": "src/knowbase/ingestion/queue/jobs.py",
+    "purpose": "Traitement worker d’un PPTX (extraction, embeddings, Qdrant)",
+    "inputs": [
+      "pptx_path",
+      "document_type",
+      "meta_path"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "mark_job_as_processing",
+      "update_job_progress",
+      "knowbase.ingestion.pipelines.pptx_pipeline.process_pptx",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "ingest_pdf_job",
+    "path": "src/knowbase/ingestion/queue/jobs.py",
+    "purpose": "Traitement worker d’un PDF",
+    "inputs": [
+      "pdf_path"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "mark_job_as_processing",
+      "update_job_progress",
+      "knowbase.ingestion.pipelines.pdf_pipeline.process_pdf",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  },
+  {
+    "name": "ingest_excel_job",
+    "path": "src/knowbase/ingestion/queue/jobs.py",
+    "purpose": "Traitement worker d’un Excel Q/A",
+    "inputs": [
+      "xlsx_path",
+      "meta"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "mark_job_as_processing",
+      "update_job_progress",
+      "knowbase.ingestion.pipelines.excel_pipeline.process_excel_rfp",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service",
+      "knowbase.api.services.import_deletion.delete_import_completely"
+    ]
+  },
+  {
+    "name": "fill_excel_job",
+    "path": "src/knowbase/ingestion/queue/jobs.py",
+    "purpose": "Worker pour le remplissage intelligent d’un RFP",
+    "inputs": [
+      "xlsx_path",
+      "meta_path"
+    ],
+    "outputs": [
+      "dict"
+    ],
+    "calls": [
+      "mark_job_as_processing",
+      "update_job_progress",
+      "knowbase.ingestion.pipelines.smart_fill_excel_pipeline.main",
+      "knowbase.api.services.import_history_redis.get_redis_import_history_service"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a new /documentation space describing architecture, APIs, execution flows, module inventory, and AI usage guidelines
- document every FastAPI endpoint with request/response schemas and service dependencies
- provide machine-readable registry.json covering endpoints and ingestion jobs

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68df71affe408332b9521d4590ff627a